### PR TITLE
Upload to travis on tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,12 @@ install:
 
 script:
     - platformio run
+    - cp -v .pio/build/megaADK/firmware.hex megaadk-firmware.hex
+
+deploy:
+    provider: releases
+    api_key: ${api_key}
+    file: "megaadk-firmware.hex"
+    skip_cleanup: true
+    on:
+        tags: true


### PR DESCRIPTION
This change introduces uploading build artifacts for tagged versions; this means that the user does not need to install platformio or the avr build toolchain to compile their code, they can download a binary and flash it to the avr with avrdude or their favourite flash tool.